### PR TITLE
Make 'locked' a field in User instead of hiding all locked users

### DIFF
--- a/lifecycle/models.py
+++ b/lifecycle/models.py
@@ -24,6 +24,7 @@ class User:
     fullname: str = ""
     email: tuple[str] = field(default_factory=tuple)
     groups: tuple[Group] = field(default_factory=tuple)
+    locked: bool = False
 
     def __post_init__(self):
 

--- a/lifecycle/source_ldap3.py
+++ b/lifecycle/source_ldap3.py
@@ -81,21 +81,18 @@ class SourceLDAP3:
         if connection.entries:
             for ldap_entry in connection.entries:
                 user_account = ldap_entry.entry_attributes_as_dict
-                ns_account_lock = user_account["nsAccountLock"]
-                locked = len(ns_account_lock) > 0 and ns_account_lock[0] == "TRUE"
 
-                if (
-                    not locked
-                    and len(user_account["uid"]) > 0
-                    and len(user_account["mail"]) > 0
-                ):
+                if len(user_account["uid"]) > 0 and len(user_account["mail"]) > 0:
                     uid = user_account["uid"][0]
+                    ns_account_lock = user_account["nsAccountLock"]
+                    locked = len(ns_account_lock) > 0 and ns_account_lock[0] == "TRUE"
                     user = User(
                         uid,
                         forename=user_account["givenName"][0],
                         surname=user_account["surName"][0],
                         email=user_account["mail"],
                         groups=[],
+                        locked=locked,
                     )
                     self.users[uid] = user
         else:


### PR DESCRIPTION
The LDAP source previously hid all users who were Locked, but on further discussion, it made sense that a new account could be created in preparation for a new user, and locked until they are due to start,
plus when a user leaves their account is deactivated, but may be held on to for mail redirection purposes, and/or reactivated later.

Note: This PR includes commits that are also in #11, but they should be mergeable in any order without friction (assuming the "rebase and merge" strategy is used)